### PR TITLE
fix: removed "close" button

### DIFF
--- a/phpmyfaq/assets/themes/default/templates/ucp.html
+++ b/phpmyfaq/assets/themes/default/templates/ucp.html
@@ -145,8 +145,7 @@
               <p class="text-center">Secret-Key: {{ twofactor_secret }}</p>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-              <button type="button" class="btn btn-primary">{{ msgSave }}</button>
+              <button type="button" class="btn btn-primary" data-bs-dismiss="modal">{{ msgSave }}</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
the "save"-button has now the function to close the modal instead of doing nothing